### PR TITLE
Crashlog muse use unixtime with ms as timestamp

### DIFF
--- a/lib/device-log/ios-crash-log.js
+++ b/lib/device-log/ios-crash-log.js
@@ -25,7 +25,7 @@ class IOSCrashLog {
       let filename = path.resolve(this.logDir, file);
       let stat = await fs.stat(filename);
       return {
-        timestamp: stat.ctime,
+        timestamp: stat.ctime.getTime(),
         level: 'ALL',
         message: await fs.readFile(filename, 'utf8')
       };


### PR DESCRIPTION
Selenium driver fails to parse ios crashlog

```stat.ctime``` returns ```Date``` object that will be converted into string like ```2017-02-04T11:15:08.264Z``` on json serialization

but selenium driver expects ```Long``` unixtime in ```timestamp``` field of log entity

```ios-log``` and android's ```logcat``` already sends number in ```timestamp```:

```
          let logObj = {
            timestamp: Date.now(),
            level: 'ALL',
            message: log
          };
```

this commit fixes format of ```timestamp``` for ios crash log